### PR TITLE
feat: add TimestampToDate script for Unix timestamp conversion

### DIFF
--- a/src-tauri/scripts/TimestampToDate.js
+++ b/src-tauri/scripts/TimestampToDate.js
@@ -1,0 +1,69 @@
+/**
+    {
+        "api":1,
+        "name":"Timestamp to Date",
+        "description":"Converts Unix timestamp to human-readable date (UTC and Local)",
+        "author":"Claude",
+        "icon":"watch",
+        "tags":"date,time,calendar,unix,timestamp"
+    }
+**/
+
+function main(input) {
+    let timestamp = input.text.trim();
+
+    // Parse the timestamp
+    let timestampNum = parseInt(timestamp);
+
+    if (isNaN(timestampNum)) {
+        input.postError("Invalid timestamp");
+        return;
+    }
+
+    // Create Date object (multiply by 1000 to convert seconds to milliseconds)
+    let date = new Date(timestampNum * 1000);
+
+    if (isNaN(date.getTime())) {
+        input.postError("Invalid timestamp");
+        return;
+    }
+
+    // Format UTC time
+    const utcOptions = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZone: 'UTC',
+        hour12: true
+    };
+    const utcFormatted = date.toLocaleString('en-US', utcOptions);
+
+    // Format local time
+    const localOptions = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: true
+    };
+    const localFormatted = date.toLocaleString('en-US', localOptions);
+
+    // Get timezone offset
+    const timezoneOffset = -date.getTimezoneOffset();
+    const offsetHours = Math.floor(Math.abs(timezoneOffset) / 60);
+    const offsetMinutes = Math.abs(timezoneOffset) % 60;
+    const offsetSign = timezoneOffset >= 0 ? '+' : '-';
+    const timezoneString = `GMT${offsetSign}${String(offsetHours).padStart(2, '0')}:${String(offsetMinutes).padStart(2, '0')}`;
+
+    // Build output
+    const output = `GMT: ${utcFormatted}\nYour time zone: ${localFormatted} [${timezoneString}]`;
+
+    input.text = output;
+}


### PR DESCRIPTION
## Summary
- Unix timestamp를 사람이 읽을 수 있는 시간으로 변환하는 스크립트 추가
- UTC 시간과 로컬 시간(타임존 포함) 모두 표시

## 관련 이슈
Closes #1

## 테스트
입력: `1766986051`
출력:
```
GMT: Monday, December 29, 2025, 5:27:31 AM
Your time zone: Monday, December 29, 2025, 2:27:31 PM [GMT+09:00]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)