### PR TITLE
feat: group tab layout mode + group colors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,5 +129,5 @@ jobs:
         run: npm run build
 
       - name: Build Tauri app (test only)
-        # --ci flag skips updater signing when TAURI_SIGNING_PRIVATE_KEY is not set
-        run: npm run tauri build -- --ci --bundles ${{ matrix.bundles }}
+        # Build verification should not require updater signing keys
+        run: npm run tauri build -- --ci --config src-tauri/tauri.ci.conf.json --no-sign --bundles ${{ matrix.bundles }}

--- a/src-tauri/tauri.ci.conf.json
+++ b/src-tauri/tauri.ci.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,9 @@ function App() {
     createGroup,
     renameGroup,
     setGroupColor,
+    setGroupBackgroundColor,
+    setGroupFontColor,
+    duplicateGroup,
     deleteGroup,
     moveTabToGroup,
     activateGroup,
@@ -167,7 +170,7 @@ function App() {
   const {
     findState,
     closeFind,
-    toggleFind,
+    openFind,
     setSearchTerm,
     setReplaceTerm,
     goToNext,
@@ -256,7 +259,7 @@ function App() {
       }
       if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
         e.preventDefault();
-        toggleFind();
+        openFind();
       }
       // Cmd+G: Next match (VS Code style)
       if ((e.metaKey || e.ctrlKey) && e.key === 'g' && !e.shiftKey) {
@@ -299,7 +302,7 @@ function App() {
     scripts,
     findState.isOpen,
     closeFind,
-    toggleFind,
+    openFind,
     goToNext,
     goToPrevious,
     replaceCurrent,
@@ -421,6 +424,7 @@ function App() {
           tabs={workspace.tabs}
           groups={workspace.groups}
           activeTabId={activeTabId}
+          groupLayoutMode={settings.groupLayoutMode}
           onSelect={setActiveTabId}
           onClose={handleCloseTab}
           onAdd={handleAddTab}
@@ -432,6 +436,9 @@ function App() {
           onCreateGroup={createGroup}
           onRenameGroup={renameGroup}
           onSetGroupColor={setGroupColor}
+          onSetGroupBackgroundColor={setGroupBackgroundColor}
+          onSetGroupFontColor={setGroupFontColor}
+          onDuplicateGroup={duplicateGroup}
           onActivateGroup={activateGroup}
           onDeleteGroup={deleteGroup}
           onReorderGroups={reorderGroups}

--- a/src/components/SettingsPopover.css
+++ b/src/components/SettingsPopover.css
@@ -264,3 +264,76 @@
   color: var(--text-primary);
   font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
 }
+
+/* Radio button styling */
+.settings-item.radio-item {
+  flex-direction: row;
+  align-items: flex-start;
+  padding: 14px 16px;
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.settings-item.radio-item.selected {
+  background: var(--bg-tertiary);
+  border-color: #007acc;
+}
+
+.settings-item.radio-item input[type='radio'] {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  margin-right: 14px;
+  margin-top: 2px;
+  cursor: pointer;
+  appearance: none;
+  background: var(--bg-tertiary);
+  border: 2px solid var(--border-color);
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.settings-item.radio-item:hover input[type='radio'] {
+  border-color: #007acc;
+}
+
+.settings-item.radio-item input[type='radio']:checked {
+  border-color: #007acc;
+  background: white;
+}
+
+.settings-item.radio-item input[type='radio']:checked::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 8px;
+  height: 8px;
+  background: #007acc;
+  border-radius: 50%;
+}
+
+.radio-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.radio-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.radio-description {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.settings-item.radio-item.selected .radio-title {
+  color: #007acc;
+}

--- a/src/components/SettingsPopover.tsx
+++ b/src/components/SettingsPopover.tsx
@@ -7,6 +7,7 @@ export interface Settings {
   enableClipboardHistory: boolean;
   enableAutoUpdate: boolean;
   opacity: number;
+  groupLayoutMode: 'dropdown' | 'two-row';
 }
 
 interface Props {
@@ -28,6 +29,10 @@ export function SettingsPopover({ settings, onUpdate, onClose }: Props) {
     }
 
     onUpdate(newSettings);
+  };
+
+  const handleGroupLayoutChange = (mode: 'dropdown' | 'two-row') => {
+    onUpdate({ ...settings, groupLayoutMode: mode });
   };
 
   return (
@@ -97,6 +102,42 @@ export function SettingsPopover({ settings, onUpdate, onClose }: Props) {
                 onChange={() => handleToggle('enableAutoUpdate')}
               />
               <span>자동 업데이트 확인</span>
+            </label>
+          </div>
+
+          <div className="settings-section">
+            <h4>그룹 표시</h4>
+
+            <label
+              className={`settings-item radio-item ${settings.groupLayoutMode === 'dropdown' ? 'selected' : ''}`}
+              onClick={() => handleGroupLayoutChange('dropdown')}
+            >
+              <input
+                type="radio"
+                name="groupLayout"
+                checked={settings.groupLayoutMode === 'dropdown'}
+                readOnly
+              />
+              <div className="radio-label">
+                <span className="radio-title">컴팩트</span>
+                <span className="radio-description">드롭다운으로 전환</span>
+              </div>
+            </label>
+
+            <label
+              className={`settings-item radio-item ${settings.groupLayoutMode === 'two-row' ? 'selected' : ''}`}
+              onClick={() => handleGroupLayoutChange('two-row')}
+            >
+              <input
+                type="radio"
+                name="groupLayout"
+                checked={settings.groupLayoutMode === 'two-row'}
+                readOnly
+              />
+              <div className="radio-label">
+                <span className="radio-title">그룹 탭</span>
+                <span className="radio-description">그룹들을 탭으로 표시 (기본값)</span>
+              </div>
             </label>
           </div>
 

--- a/src/components/TabBar.css
+++ b/src/components/TabBar.css
@@ -70,12 +70,23 @@
   top: 100%;
   left: 0;
   min-width: 180px;
+  max-height: 320px; /* 그룹이 많을 때 스크롤 가능하도록 제한 */
+  overflow-y: auto;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 0 0 4px 4px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   z-index: 100;
   padding: 4px 0;
+}
+
+.group-dropdown-menu::-webkit-scrollbar {
+  width: 6px;
+}
+
+.group-dropdown-menu::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb, #b0b0b0);
+  border-radius: 999px;
 }
 
 .group-dropdown-header {
@@ -270,6 +281,7 @@
   display: flex;
   height: 100%;
   align-items: flex-end;
+  justify-content: flex-start; /* 탭을 왼쪽 정렬 */
   overflow-x: auto;
   flex: 1;
   padding-left: 0; /* Align with group selector */
@@ -396,6 +408,8 @@
   background: var(--bg-secondary);
   border-left: 1px solid var(--border-color);
   z-index: 10;
+  flex-shrink: 0; /* 좁은 폭에서도 고정 영역 유지 */
+  min-width: 64px;
 }
 
 .action-btn {
@@ -415,4 +429,339 @@
 .action-btn:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
+}
+
+/* --- Two-Row Layout Mode --- */
+
+.tab-bar-container.two-row-mode {
+  flex-direction: column;
+  height: 64px; /* 32px * 2 */
+  align-items: stretch; /* 세로 배치 시 너비를 꽉 채워 왼쪽 정렬 유지 */
+}
+
+.group-tabs-row {
+  display: flex;
+  align-items: center;
+  height: 32px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.group-tabs-scroll {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  flex: 1;
+  min-width: 0; /* 스크롤 활성화를 위해 필수 */
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-left: 0; /* 탭 행과 동일하게 여백 제거 */
+}
+
+.group-tabs-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.group-tab-item {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  height: 28px; /* 탭과 동일한 높이 */
+  min-width: 80px;
+  max-width: 150px;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    height 0.2s,
+    color 0.2s;
+  border-right: 1px solid var(--border-color);
+  position: relative;
+  flex-shrink: 0;
+  color: var(--text-primary); /* 기본 색상, 인라인 스타일로 오버라이드 가능 */
+}
+
+.group-tab-item:hover {
+  background: var(--bg-tertiary);
+}
+
+.group-tab-item.active {
+  background: var(--bg-primary);
+  font-weight: 600;
+  border-bottom: 2px solid currentColor; /* 폰트 색상과 동일하게 */
+  height: 32px; /* 일반탭 활성 높이와 동일 */
+}
+
+.group-tab-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+  flex-shrink: 0;
+  cursor: pointer;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+}
+
+.group-tab-dot:hover {
+  transform: scale(1.3);
+  box-shadow:
+    0 0 0 2px var(--bg-secondary),
+    0 0 0 3px currentColor;
+}
+
+.group-tab-name {
+  flex: 1;
+  font-size: 11px; /* 탭 폰트 크기와 통일 */
+  font-weight: inherit;
+  color: inherit; /* 부모(group-tab-item)의 커스텀 색상 상속 */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 6px;
+}
+
+.group-tab-edit-input {
+  background: transparent;
+  border: 1px solid #007acc;
+  border-radius: 2px;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+  padding: 2px 4px;
+  margin: 0;
+  width: 100%;
+}
+
+.group-tab-item.new-group-tab {
+  min-width: 32px;
+  max-width: 32px;
+  justify-content: center;
+  padding: 0;
+  color: var(--text-secondary);
+}
+
+.group-tab-item.new-group-tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.group-tab-item.new-group-tab .plus-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+/* 스크롤과 분리된 신규 그룹 버튼 */
+.group-new-btn {
+  width: 32px;
+  min-width: 32px;
+  max-width: 32px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-left: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  transition:
+    background 0.2s,
+    color 0.2s;
+  flex-shrink: 0;
+}
+
+.group-new-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* 스크롤 불필요 시 마지막 그룹 옆에 인라인 표시 */
+.group-new-btn.inline {
+  border-left: none;
+  border-right: 1px solid var(--border-color);
+  background: transparent;
+}
+
+.group-new-btn.inline:hover {
+  background: var(--bg-tertiary);
+}
+
+.color-picker-inline {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  z-index: 101;
+  width: 90px;
+}
+
+.color-picker-inline .color-option {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  cursor: pointer;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+  border: 2px solid transparent;
+}
+
+.color-picker-inline .color-option:hover {
+  transform: scale(1.15);
+}
+
+.color-picker-inline .color-option.selected {
+  border-color: var(--text-primary);
+  box-shadow: 0 0 0 2px var(--bg-secondary);
+}
+
+/* Group Row Actions (Settings button in two-row mode) */
+.group-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 8px;
+  flex-shrink: 0;
+  min-width: 70px; /* 고정 영역 최소 너비 보장 */
+  border-left: 1px solid var(--border-color);
+  height: 100%;
+}
+
+.tab-bar-action {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 14px;
+  transition: all 0.2s;
+  border-radius: 4px;
+}
+
+.tab-bar-action:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.tab-bar-action.has-indicator::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 6px;
+  height: 6px;
+  background: #007acc;
+  border-radius: 50%;
+}
+
+/* Adjust tabs-list in two-row mode */
+.tab-bar-container.two-row-mode .tabs-list {
+  padding-left: 0; /* 그룹탭과 동일하게 제로 베이스 정렬 */
+  border-bottom: none;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+/* Color Picker Modal */
+.color-picker-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.color-picker-modal {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  min-width: 280px;
+}
+
+.color-picker-header {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 12px;
+}
+
+.color-input {
+  width: 100%;
+  padding: 8px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+  margin-bottom: 12px;
+}
+
+.color-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+}
+
+.color-preset-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 6px;
+}
+
+.color-preset-option {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition:
+    transform 0.15s,
+    border-color 0.15s;
+}
+
+.color-preset-option:hover {
+  transform: scale(1.15);
+  border-color: var(--text-primary);
+}
+
+/* Custom color tabs - hover/active effects */
+.tab-item[style*='background'] {
+  transition:
+    filter 0.2s,
+    opacity 0.2s,
+    background 0.2s,
+    color 0.2s,
+    transform 0.2s ease-out,
+    max-width 0.2s ease-out,
+    min-width 0.2s ease-out,
+    padding 0.2s ease-out;
+}
+
+.tab-item[style*='background']:hover {
+  filter: brightness(1.1);
+}
+
+.tab-item[style*='background'].active {
+  filter: brightness(1.2);
+  border-bottom: 2px solid currentColor;
 }

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,12 +1,21 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import './TabBar.css';
-import { Tab, TabGroup, DEFAULT_GROUP_ID, GROUP_COLOR_PALETTE, GroupColor } from '../lib/tabGroups';
+import {
+  Tab,
+  TabGroup,
+  DEFAULT_GROUP_ID,
+  GROUP_COLOR_PALETTE,
+  PRESET_COLORS,
+  GroupColor,
+} from '../lib/tabGroups';
 import { ContextMenu, MenuItem } from './ContextMenu';
 
 interface Props {
   tabs: Tab[];
   groups: TabGroup[];
   activeTabId: string;
+  groupLayoutMode?: 'dropdown' | 'two-row';
   onSelect: (id: string) => void;
   onClose: (id: string) => void;
   onAdd: () => void;
@@ -22,9 +31,12 @@ interface Props {
   onCloseToRight?: (id: string) => void;
   onCloseToLeft?: (id: string) => void;
   // Group actions
-  onCreateGroup?: (title: string) => void;
+  onCreateGroup?: (title: string) => string;
   onRenameGroup?: (groupId: string, title: string) => void;
   onSetGroupColor?: (groupId: string, color: GroupColor) => void;
+  onSetGroupBackgroundColor?: (groupId: string, color: string | undefined) => void;
+  onSetGroupFontColor?: (groupId: string, color: string | undefined) => void;
+  onDuplicateGroup?: (groupId: string) => void;
   onActivateGroup?: (groupId: string) => void;
   onDeleteGroup?: (groupId: string) => void;
   onReorderGroups?: (fromIndex: number, toIndex: number) => void;
@@ -35,6 +47,7 @@ export function TabBar({
   tabs,
   groups,
   activeTabId,
+  groupLayoutMode = 'two-row',
   onSelect,
   onClose,
   onAdd,
@@ -51,6 +64,9 @@ export function TabBar({
   onCreateGroup,
   onRenameGroup,
   onSetGroupColor,
+  onSetGroupBackgroundColor,
+  onSetGroupFontColor,
+  onDuplicateGroup,
   onActivateGroup,
   onDeleteGroup,
   onReorderGroups,
@@ -72,9 +88,19 @@ export function TabBar({
     tabId: string;
     position: { x: number; y: number };
   } | null>(null);
+  const [groupContextMenu, setGroupContextMenu] = useState<{
+    groupId: string;
+    position: { x: number; y: number };
+  } | null>(null);
+  const [colorPickerState, setColorPickerState] = useState<{
+    groupId: string;
+    type: 'background' | 'font';
+  } | null>(null);
   const [closingTabs, setClosingTabs] = useState<Set<string>>(new Set());
+  const [needsGroupScroll, setNeedsGroupScroll] = useState(false); // 그룹탭 스크롤 필요 여부
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const groupScrollRef = useRef<HTMLDivElement>(null); // 그룹탭 스크롤 컨테이너
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingDragRef = useRef<{ index: number; x: number; y: number } | null>(null);
   const currentMouseRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
@@ -102,6 +128,34 @@ export function TabBar({
     }
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isGroupDropdownOpen, dragState.dragging]);
+
+  // 그룹탭 스크롤 필요 여부 감지
+  useEffect(() => {
+    if (groupLayoutMode !== 'two-row') return;
+    const scrollContainer = groupScrollRef.current;
+    if (!scrollContainer) return;
+
+    const checkScrollNeeded = () => {
+      const needsScroll = scrollContainer.scrollWidth > scrollContainer.clientWidth;
+      setNeedsGroupScroll(needsScroll);
+    };
+
+    // 초기 체크
+    checkScrollNeeded();
+
+    // ResizeObserver로 크기 변화 감지
+    const resizeObserver = new ResizeObserver(checkScrollNeeded);
+    resizeObserver.observe(scrollContainer);
+
+    // MutationObserver로 자식 변화 감지 (그룹 추가/삭제)
+    const mutationObserver = new MutationObserver(checkScrollNeeded);
+    mutationObserver.observe(scrollContainer, { childList: true, subtree: true });
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [groupLayoutMode, groups.length]); // 모드/그룹 변경 시 체크
 
   // Cancel long-press timer helper
   const cancelLongPress = useCallback(() => {
@@ -255,6 +309,76 @@ export function TabBar({
     setContextMenu(null);
   };
 
+  const handleGroupContextMenu = (e: React.MouseEvent, groupId: string) => {
+    if (groupId === DEFAULT_GROUP_ID) return; // Default 그룹 보호
+    e.preventDefault();
+    setGroupContextMenu({
+      groupId,
+      position: { x: e.clientX, y: e.clientY },
+    });
+  };
+
+  // 그룹 컨텍스트 메뉴만 닫기 (ContextMenu의 onClose 용)
+  const handleCloseGroupContextMenu = () => {
+    setGroupContextMenu(null);
+    // 주의: colorPickerState는 여기서 초기화하지 않음
+    // ContextMenu의 handleItemClick이 onClick 후 onClose를 호출하기 때문
+  };
+
+  // 오버레이 클릭 시 모달과 메뉴 모두 닫기
+  const handleCloseColorPicker = () => {
+    setGroupContextMenu(null);
+    setColorPickerState(null);
+  };
+
+  const getGroupContextMenuItems = (groupId: string): MenuItem[] => {
+    const group = groups.find((g) => g.id === groupId);
+    if (!group) return [];
+
+    const hasColors = Boolean(group.backgroundColor || group.fontColor);
+
+    return [
+      {
+        label: '배경색 변경',
+        onClick: () => {
+          setGroupContextMenu(null); // 컨텍스트 메뉴 닫기
+          setColorPickerState({ groupId, type: 'background' });
+        },
+      },
+      {
+        label: '폰트 색상 변경',
+        onClick: () => {
+          setGroupContextMenu(null); // 컨텍스트 메뉴 닫기
+          setColorPickerState({ groupId, type: 'font' });
+        },
+      },
+      {
+        label: '색상 초기화',
+        onClick: () => {
+          onSetGroupBackgroundColor?.(groupId, undefined);
+          onSetGroupFontColor?.(groupId, undefined);
+          handleCloseGroupContextMenu();
+        },
+        disabled: !hasColors,
+      },
+      { divider: true, label: '' },
+      {
+        label: '그룹 복제',
+        onClick: () => {
+          onDuplicateGroup?.(groupId);
+          handleCloseGroupContextMenu();
+        },
+      },
+      {
+        label: '그룹 닫기',
+        onClick: () => {
+          onDeleteGroup?.(groupId);
+          handleCloseGroupContextMenu();
+        },
+      },
+    ];
+  };
+
   // Build context menu items
   const getContextMenuItems = (tabId: string): MenuItem[] => {
     const tabIndex = currentGroupTabs.findIndex((t) => t.id === tabId);
@@ -314,6 +438,76 @@ export function TabBar({
         disabled: !hasTabsToLeft,
       },
     ];
+  };
+
+  // Render Color Picker Modal
+  const renderColorPickerModal = () => {
+    if (!colorPickerState) return null;
+
+    const group = groups.find((g) => g.id === colorPickerState.groupId);
+    if (!group) return null;
+
+    const currentColor =
+      colorPickerState.type === 'background' ? group.backgroundColor : group.fontColor;
+
+    const commitColor = (raw: string) => {
+      const value = raw.trim();
+      if (colorPickerState.type === 'background') {
+        onSetGroupBackgroundColor?.(colorPickerState.groupId, value || undefined);
+      } else {
+        onSetGroupFontColor?.(colorPickerState.groupId, value || undefined);
+      }
+      handleCloseColorPicker();
+    };
+
+    const applyColor = (color: string) => {
+      if (colorPickerState.type === 'background') {
+        onSetGroupBackgroundColor?.(colorPickerState.groupId, color);
+      } else {
+        onSetGroupFontColor?.(colorPickerState.groupId, color);
+      }
+      handleCloseColorPicker();
+    };
+
+    return createPortal(
+      <div className="color-picker-overlay" onClick={handleCloseColorPicker}>
+        <div className="color-picker-modal" onClick={(e) => e.stopPropagation()}>
+          <div className="color-picker-header">
+            {colorPickerState.type === 'background' ? '배경색 선택' : '폰트 색상 선택'}
+          </div>
+
+          <input
+            type="text"
+            className="color-input"
+            placeholder="#000000 또는 rgb(0,0,0)"
+            defaultValue={currentColor || ''}
+            onBlur={(e) => commitColor(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commitColor(e.currentTarget.value);
+              } else if (e.key === 'Escape') {
+                handleCloseColorPicker();
+              }
+            }}
+          />
+
+          <div className="color-preset-grid">
+            {PRESET_COLORS.map((color) => (
+              <span
+                key={color}
+                className="color-preset-option"
+                style={{ backgroundColor: color }}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => applyColor(color)}
+                title={color}
+              />
+            ))}
+          </div>
+        </div>
+      </div>,
+      document.body
+    );
   };
 
   // Render Group Selector (Dropdown Trigger)
@@ -470,21 +664,132 @@ export function TabBar({
     );
   };
 
+  // Render Group Tabs (Two-Row Mode)
+  const renderGroupTabs = () => {
+    // 새 그룹 버튼 컴포넌트
+    const newGroupButton = (
+      <div
+        className={`group-new-btn ${!needsGroupScroll ? 'inline' : ''}`}
+        onClick={() => {
+          const newGroupId = onCreateGroup?.('New Group');
+          if (newGroupId) onActivateGroup?.(newGroupId);
+        }}
+        title="Create new group"
+      >
+        <span className="plus-icon">+</span>
+      </div>
+    );
+
+    return (
+      <div className="group-tabs-row">
+        <div className="group-tabs-scroll" ref={groupScrollRef}>
+          {groups.map((group) => {
+            const isActive = group.id === activeGroupId;
+
+            // 그룹 커스텀 색상 스타일 적용
+            const groupStyle: React.CSSProperties = {};
+            if (group.backgroundColor) groupStyle.backgroundColor = group.backgroundColor;
+            if (group.fontColor) groupStyle.color = group.fontColor;
+
+            return (
+              <div
+                key={group.id}
+                className={`group-tab-item ${isActive ? 'active' : ''}`}
+                style={groupStyle}
+                onClick={() => !isActive && onActivateGroup?.(group.id)}
+                onContextMenu={(e) => handleGroupContextMenu(e, group.id)}
+                onDoubleClick={(e) => {
+                  e.stopPropagation();
+                  handleDoubleClickGroup(group);
+                }}
+                title={group.title}
+              >
+                {editingGroupId === group.id ? (
+                  <input
+                    ref={inputRef}
+                    className="group-tab-edit-input"
+                    value={tempTitle}
+                    onChange={(e) => setTempTitle(e.target.value)}
+                    onBlur={handleSave}
+                    onKeyDown={handleKeyDown}
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                ) : (
+                  <span className="group-tab-name">{group.title}</span>
+                )}
+              </div>
+            );
+          })}
+          {/* 스크롤 불필요 시 마지막 그룹 옆에 버튼 표시 */}
+          {!needsGroupScroll && newGroupButton}
+        </div>
+
+        {/* 스크롤 필요 시 고정 위치에 버튼 표시 */}
+        {needsGroupScroll && newGroupButton}
+
+        {/* Action Buttons (Settings) - Fixed on right */}
+        <div className="tab-bar-actions group-row-actions">
+          {hasHistory && (
+            <button
+              className="tab-bar-action"
+              onClick={onToggleClipboard}
+              title="Clipboard History"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
+                <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
+              </svg>
+            </button>
+          )}
+          <button
+            className={`tab-bar-action ${hasSessions ? 'has-indicator' : ''}`}
+            onClick={onToggleSessions}
+            title="Session History"
+          >
+            ⋯
+          </button>
+          <button className="tab-bar-action" onClick={onToggleSettings} title="Settings">
+            ⚙
+          </button>
+        </div>
+      </div>
+    );
+  };
+
   // Filter tabs for active group
   const currentGroupTabs = tabs.filter((t) => t.groupId === activeGroupId);
 
   return (
-    <div className="tab-bar-container" data-tauri-drag-region>
-      {/* Group Selector */}
-      {renderGroupSelector()}
+    <div
+      className={`tab-bar-container ${groupLayoutMode === 'two-row' ? 'two-row-mode' : ''}`}
+      data-tauri-drag-region
+    >
+      {/* Conditional Group Display */}
+      {groupLayoutMode === 'two-row' ? renderGroupTabs() : renderGroupSelector()}
 
       <div className="tabs-list" data-tauri-drag-region>
         {currentGroupTabs.map((tab) => {
           const isClosing = closingTabs.has(tab.id);
+          const group = groups.find((g) => g.id === tab.groupId);
+
+          const customStyle: React.CSSProperties = {};
+          if (group?.backgroundColor) customStyle.backgroundColor = group.backgroundColor;
+          if (group?.fontColor) customStyle.color = group.fontColor;
+
           return (
             <div
               key={tab.id}
               className={`tab-item ${tab.id === activeTabId ? 'active' : ''} ${isClosing ? 'closing' : ''}`}
+              style={customStyle}
               onClick={() => onSelect(tab.id)}
               onDoubleClick={() => handleDoubleClickTab(tab)}
               onContextMenu={(e) => handleContextMenu(e, tab.id)}
@@ -519,13 +824,55 @@ export function TabBar({
         </div>
       </div>
 
-      <div className="tab-bar-actions" data-tauri-drag-region>
-        {hasHistory && (
-          <div
-            className="action-btn clipboard-btn"
-            onClick={onToggleClipboard}
-            title="Clipboard History"
-          >
+      {/* Action Buttons (only in dropdown mode) */}
+      {groupLayoutMode === 'dropdown' && (
+        <div className="tab-bar-actions" data-tauri-drag-region>
+          {hasHistory && (
+            <div
+              className="action-btn clipboard-btn"
+              onClick={onToggleClipboard}
+              title="Clipboard History"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
+                <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
+              </svg>
+            </div>
+          )}
+
+          {hasSessions && (
+            <div
+              className="action-btn session-btn"
+              onClick={onToggleSessions}
+              title="Restore Session"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path>
+                <path d="M3 3v5h5"></path>
+                <path d="M12 7v5l4 2"></path>
+              </svg>
+            </div>
+          )}
+
+          <div className="action-btn settings-btn" onClick={onToggleSettings} title="Settings">
             <svg
               width="14"
               height="14"
@@ -536,51 +883,12 @@ export function TabBar({
               strokeLinecap="round"
               strokeLinejoin="round"
             >
-              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-              <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
+              <circle cx="12" cy="12" r="3"></circle>
             </svg>
           </div>
-        )}
-
-        {hasSessions && (
-          <div
-            className="action-btn session-btn"
-            onClick={onToggleSessions}
-            title="Restore Session"
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path>
-              <path d="M3 3v5h5"></path>
-              <path d="M12 7v5l4 2"></path>
-            </svg>
-          </div>
-        )}
-
-        <div className="action-btn settings-btn" onClick={onToggleSettings} title="Settings">
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
-            <circle cx="12" cy="12" r="3"></circle>
-          </svg>
         </div>
-      </div>
+      )}
 
       {/* Context Menu */}
       {contextMenu && (
@@ -590,6 +898,18 @@ export function TabBar({
           onClose={handleCloseContextMenu}
         />
       )}
+
+      {/* Group Context Menu */}
+      {groupContextMenu && (
+        <ContextMenu
+          items={getGroupContextMenuItems(groupContextMenu.groupId)}
+          position={groupContextMenu.position}
+          onClose={handleCloseGroupContextMenu}
+        />
+      )}
+
+      {/* Color Picker Modal */}
+      {renderColorPickerModal()}
     </div>
   );
 }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -9,6 +9,7 @@ export interface Settings {
   enableClipboardHistory: boolean;
   enableAutoUpdate: boolean;
   opacity: number;
+  groupLayoutMode: 'dropdown' | 'two-row';
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -18,6 +19,7 @@ export const DEFAULT_SETTINGS: Settings = {
   enableClipboardHistory: true,
   enableAutoUpdate: true,
   opacity: 100,
+  groupLayoutMode: 'two-row',
 };
 
 export function useSettings() {

--- a/src/hooks/useWorkspace.ts
+++ b/src/hooks/useWorkspace.ts
@@ -10,9 +10,12 @@ import {
   setGroupColor,
   renameGroup,
   deleteGroup,
+  duplicateGroup,
   moveTabToGroup,
   findTabToActivateInGroup,
   reorderGroups,
+  setGroupBackgroundColor,
+  setGroupFontColor,
   GroupColor,
 } from '../lib/tabGroups';
 
@@ -407,6 +410,36 @@ export function useWorkspace() {
     });
   }, []);
 
+  const handleSetGroupBackgroundColor = useCallback(
+    (groupId: string, backgroundColor: string | undefined) => {
+      setWorkspace((prev) => ({
+        ...prev,
+        groups: setGroupBackgroundColor(prev.groups, groupId, backgroundColor),
+      }));
+    },
+    []
+  );
+
+  const handleSetGroupFontColor = useCallback((groupId: string, fontColor: string | undefined) => {
+    setWorkspace((prev) => ({
+      ...prev,
+      groups: setGroupFontColor(prev.groups, groupId, fontColor),
+    }));
+  }, []);
+
+  const handleDuplicateGroup = useCallback((groupId: string) => {
+    const newGroupId = generateId();
+    setWorkspace((prev) => {
+      const { groups, tabs } = duplicateGroup(prev.groups, prev.tabs, groupId, newGroupId);
+      return {
+        ...prev,
+        groups,
+        tabs,
+      };
+    });
+    return newGroupId;
+  }, []);
+
   // Session Restore Helper
   const restoreSession = useCallback((newTabs: Tab[], selectFirst = true) => {
     // Session restore usually provides just tabs. We need to normalize it into the workspace.
@@ -458,7 +491,10 @@ export function useWorkspace() {
     createGroup: handleCreateGroup,
     toggleGroup: handleToggleGroup,
     setGroupColor: handleSetGroupColor,
+    setGroupBackgroundColor: handleSetGroupBackgroundColor,
+    setGroupFontColor: handleSetGroupFontColor,
     renameGroup: handleRenameGroup,
+    duplicateGroup: handleDuplicateGroup,
     deleteGroup: handleDeleteGroup,
     moveTabToGroup: handleMoveTabToGroup,
     activateGroup: handleActivateGroup,

--- a/src/lib/tabGroups.ts
+++ b/src/lib/tabGroups.ts
@@ -25,6 +25,33 @@ export const GROUP_COLOR_PALETTE: GroupColor[] = [
   '#64748b',
 ];
 
+export const PRESET_COLORS = [
+  '#ffffff',
+  '#f0f0f0',
+  '#d0d0d0',
+  '#a0a0a0',
+  '#808080',
+  '#404040',
+  '#202020',
+  '#000000',
+  '#ff0000',
+  '#ff8800',
+  '#ffff00',
+  '#00ff00',
+  '#00ffff',
+  '#0088ff',
+  '#8800ff',
+  '#ff00ff',
+  '#ffcccc',
+  '#ffe6cc',
+  '#ffffcc',
+  '#ccffcc',
+  '#ccffff',
+  '#cce6ff',
+  '#e6ccff',
+  '#ffccff',
+];
+
 export interface Tab {
   id: string;
   title: string;
@@ -36,6 +63,8 @@ export interface TabGroup {
   id: string;
   title: string;
   color: GroupColor;
+  backgroundColor?: string;
+  fontColor?: string;
   collapsed: boolean;
 }
 
@@ -93,10 +122,16 @@ function normalizeGroup(value: unknown, fallbackIndex: number): TabGroup {
   const title =
     typeof value.title === 'string' && value.title.trim() ? value.title.trim() : 'Group';
   const collapsed = typeof value.collapsed === 'boolean' ? value.collapsed : false;
+  const backgroundColor =
+    typeof value.backgroundColor === 'string' ? value.backgroundColor : undefined;
+  const fontColor = typeof value.fontColor === 'string' ? value.fontColor : undefined;
+
   return {
     id: value.id,
     title,
     color: normalizeColor(value.color),
+    backgroundColor,
+    fontColor,
     collapsed,
   };
 }
@@ -259,4 +294,58 @@ export function reorderGroups(groups: TabGroup[], fromIndex: number, toIndex: nu
   const [item] = next.splice(fromIndex, 1);
   next.splice(toIndex, 0, item);
   return next;
+}
+
+export function setGroupBackgroundColor(
+  groups: TabGroup[],
+  groupId: string,
+  backgroundColor: string | undefined
+): TabGroup[] {
+  return groups.map((g) => (g.id === groupId ? { ...g, backgroundColor } : g));
+}
+
+export function setGroupFontColor(
+  groups: TabGroup[],
+  groupId: string,
+  fontColor: string | undefined
+): TabGroup[] {
+  return groups.map((g) => (g.id === groupId ? { ...g, fontColor } : g));
+}
+
+export function duplicateGroup(
+  groups: TabGroup[],
+  tabs: Tab[],
+  groupId: string,
+  newGroupId: string
+): { groups: TabGroup[]; tabs: Tab[] } {
+  const sourceGroup = groups.find((g) => g.id === groupId);
+  if (!sourceGroup) {
+    return { groups, tabs };
+  }
+
+  // 그룹 복제
+  const newGroup: TabGroup = {
+    ...sourceGroup,
+    id: newGroupId,
+    title: `${sourceGroup.title} (copy)`,
+  };
+
+  // 해당 그룹의 탭들 복제
+  const groupTabs = tabs.filter((t) => t.groupId === groupId);
+  const newTabs = groupTabs.map((tab) => ({
+    ...tab,
+    id: `${tab.id}-copy-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+    title: `${tab.title} (copy)`,
+    groupId: newGroupId,
+  }));
+
+  // 원본 그룹 바로 다음에 복제된 그룹 삽입
+  const sourceIndex = groups.findIndex((g) => g.id === groupId);
+  const newGroups = [...groups];
+  newGroups.splice(sourceIndex + 1, 0, newGroup);
+
+  return {
+    groups: newGroups,
+    tabs: [...tabs, ...newTabs],
+  };
 }


### PR DESCRIPTION
그룹 표시 모드(2줄/드롭다운) 설정을 추가하고, 그룹 커스텀 배경/폰트 색상 및 그룹 복제를 지원합니다.\n2줄 모드에서도 클립보드 히스토리 버튼이 노출됩니다.\n테스트: npm test, npm run lint, npm run build.